### PR TITLE
Implement IERC1155Receiver for ArchetypeBatch

### DIFF
--- a/contracts/ArchetypeBatch.sol
+++ b/contracts/ArchetypeBatch.sol
@@ -19,8 +19,9 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
+import "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
 
-contract ArchetypeBatch is Ownable {
+contract ArchetypeBatch is Ownable, IERC1155Receiver {
 
     // Execute multiple calls in a single transaction
     // targets: The addresses of the contracts
@@ -72,5 +73,21 @@ contract ArchetypeBatch is Ownable {
         for (uint256 i = 0; i < ids.length; i++) {
             IERC1155(asset).safeTransferFrom(address(this), recipient, ids[i], amounts[i], "");
         }
+    }
+
+    // Required for receiving single ERC1155 tokens
+    function onERC1155Received(address operator, address from, uint256 id, uint256 value, bytes calldata data) external pure returns (bytes4) {
+        return IERC1155Receiver.onERC1155Received.selector;
+    }
+
+    // Required for receiving batch ERC1155 tokens
+    function onERC1155BatchReceived(address operator, address from, uint256[] calldata ids, uint256[] calldata values, bytes calldata data) external pure returns (bytes4) {
+        return IERC1155Receiver.onERC1155BatchReceived.selector;
+    }
+
+    // Required by IERC165 (which IERC1155Receiver inherits from)
+    function supportsInterface(bytes4 interfaceId) external pure override returns (bool) {
+        return interfaceId == type(IERC1155Receiver).interfaceId || 
+               interfaceId == type(IERC165).interfaceId;
     }
 }

--- a/contracts/ERC1155/ArchetypeErc1155.sol
+++ b/contracts/ERC1155/ArchetypeErc1155.sol
@@ -99,7 +99,7 @@ contract ArchetypeErc1155 is Initializable, ERC1155Upgradeable, OwnableUpgradeab
     address affiliate,
     bytes calldata signature
   ) external payable {
-    mintTo(auth, quantity, msg.sender, tokenId, affiliate, signature);
+    mintTo(auth, quantity, _msgSender(), tokenId, affiliate, signature);
   }
 
   function batchMintTo(
@@ -220,7 +220,7 @@ contract ArchetypeErc1155 is Initializable, ERC1155Upgradeable, OwnableUpgradeab
     );
 
     if (invite.limit < invite.maxSupply) {
-      _minted[msg.sender][auth.key] += args.totalQuantity;
+      _minted[_msgSender()][auth.key] += args.totalQuantity;
     }
     if (invite.maxSupply < 2**32 - 1) {
       _listSupply[auth.key] += args.totalQuantity;


### PR DESCRIPTION
https://docs.openzeppelin.com/contracts/5.x/api/token/erc1155#IERC1155Receiver

Smart contracts that receive ERC1155 tokens must implement the IERC1155Receiver interface, our current ArchetypeBatch contracts do not work with batching ERC1155 tokens.

Deployed this new ArchetypeBatch version to Superposition: https://explorer.superposition.so/address/0x691a208095E061829bE3d3576bD0B1DC894Ba900?tab=index

Deployed new 1155Factory, ArchetypeLogic and Archetype to Superposition as well (can see all from here https://explorer.superposition.so/address/0xE0A000E8D4E4533A7c28ce82F6d7Eb45E6a43F39?tab=txs)


Made a new collection with this factory and can see that batch 1155 mints now work https://explorer.superposition.so/tx/0x1fc6fcda52492105c0875dc95b37cdf24e549c18e7e2ed985e65c5c924360a9b?tab=index

We were running into the following error with the old batch contract:
```
EstimateGasExecutionError: Execution reverted with reason: �y� 4ERC1155: transfer to non-ERC1155Receiver implementer.

Estimate Gas Arguments:
  from:   0xec0d98A84EDB7f6e9eBE8DA22218d558A031e531
  to:     0xEa49e7bE310716dA66725c84a5127d2F6A202eAf
  value:  0.00001 ETH
```
